### PR TITLE
Variable "helm_history_max" is now really working (it before was pars…

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -60,7 +60,7 @@ if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then
   version=""
 else
   if [ -z "$version" ]; then
-    echo "invalid payload (missing version if chart is from repository."
+    echo "invalid payload (missing version if chart is from repository)."
     exit 1
   fi
   # get from a repo
@@ -101,7 +101,7 @@ helm_upgrade() {
   if [ "$release" == "" ]; then
     upgrade_args=("install" $chart_full "--namespace=$namespace")
   else
-    upgrade_args=("upgrade" "--install" "$release" $chart_full "--namespace=$namespace")
+    upgrade_args=("upgrade" "$release" $chart_full "--install" "--namespace=$namespace")
   fi
 
   if [ -n "$values" ]; then
@@ -152,6 +152,10 @@ helm_upgrade() {
 
   if [ "$reset_values" == "true" ]; then
     upgrade_args+=("--reset-values")
+  fi
+
+  if [ -n "$history_max" ]; then
+    upgrade_args+=("--history-max=$history_max")
   fi
 
   logfile="/tmp/log"


### PR DESCRIPTION
…ed but not used)

- Appended **$history_max** variable to **$upgrade_args** (Note: if use `--helm_history_max N` instead `--helm_history_max=N` there is shell be error like `Error: unknown flag: --history-max N`).
- Changed arguments order in helm command to correspond docs (`helm upgrade [RELEASE] [CHART] [flags]`)
- Small text error