### PR TITLE
Deleted check for empty variable **$version**

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -59,10 +59,6 @@ if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then
   chart_full="$source/$chart"
   version=""
 else
-  if [ -z "$version" ]; then
-    echo "invalid payload (missing version if chart is from repository)."
-    exit 1
-  fi
   # get from a repo
   chart_full="$chart"
 fi


### PR DESCRIPTION
Checking that the variable **$version** is empty is completely redundant and limits functionality of helm. Because there are now way to use latest chart in repo (not for local) if `--version` parameter is set.

Docs:
```
--version string
specify the exact chart version to install. If this is not specified, the latest version is installed
```