### PR TITLE
Deployment fails without release name #25

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -90,12 +90,13 @@ set_overridden_values() {
 
 current_deployed() {
   local release="$1"
-  $helm_bin history --max 20 $release --namespace $namespace | grep -i "DEPLOYED"
+  # Only one result in history because we need to contol only last release
+  $helm_bin history --max 1 $release --namespace $namespace | grep -i "DEPLOYED"
 }
 
 helm_upgrade() {
   if [ "$release" == "" ]; then
-    upgrade_args=("install" $chart_full "--namespace=$namespace")
+    upgrade_args=("install" $chart_full "--generate-name" "--namespace=$namespace")
   else
     upgrade_args=("upgrade" "$release" $chart_full "--install" "--namespace=$namespace")
   fi
@@ -150,7 +151,8 @@ helm_upgrade() {
     upgrade_args+=("--reset-values")
   fi
 
-  if [ -n "$history_max" ]; then
+  # Only if upgrade we can use history_max flag
+  if [ -n "$release" ] && [ -n "$history_max" ]; then
     upgrade_args+=("--history-max=$history_max")
   fi
 
@@ -169,7 +171,10 @@ helm_upgrade() {
 
 
   echo "Running command helm ${helm_echo_args[@]} | tee $logfile"
-  $helm_bin "${helm_args[@]}" | tee "$logfile"
+  upgrade_result=$($helm_bin "${helm_args[@]}" | tee "$logfile")
+  echo "$upgrade_result"
+
+  deployed_release=$(echo $upgrade_result | head -n 1 | awk '{ print $2 }')
 
   if [ -n "$wait" ] && [ "$wait" -gt "0" ]; then
     echo "Waiting for $wait Seconds"
@@ -215,6 +220,10 @@ else
   helm_upgrade
 
   if [ "$debug" != "true" ]; then
+    # If release is empty
+    if [ -z "$release" ]; then
+      release=$deployed_release
+    fi
     deployed=$(current_deployed "$release")
     revision=$(echo $deployed | awk '{ print $1 }')
     chart=$(echo $deployed | awk '{ print $8 }')


### PR DESCRIPTION
https://github.com/Typositoire/concourse-helm3-resource/issues/25

- Changed `--max` parameter in `helm history` to 1 because we need to check only latest revision
- Added `--generate-name` parameter to `helm install` if **$release** var is empty
- Selective add of parameter `--history-max` only if `helm upgrade`
- Getting release name from `helm` output if release name var is empty (for checking deployed release)